### PR TITLE
Keep border-radius for translation button on hover

### DIFF
--- a/ui/dasher/css/_dasher.scss
+++ b/ui/dasher/css/_dasher.scss
@@ -96,6 +96,7 @@
       &:hover {
         background: $c-link;
         color: $c-over;
+        border-radius: 0 0 0 6px;
       }
     }
   }


### PR DESCRIPTION

<img width="155" height="105" alt="" src="https://github.com/user-attachments/assets/b8d8d508-2dc8-41d7-bc18-53d3a9f10477" />

Currently like this because the rounded border is set on the main dasher
<br>

<img width="155" height="99" alt="" src="https://github.com/user-attachments/assets/8fdee30f-8133-430e-b82a-0cb6e8ee29de" />
